### PR TITLE
Initialization hard fault memaccess

### DIFF
--- a/shared-module/bno080/BNO080.c
+++ b/shared-module/bno080/BNO080.c
@@ -768,6 +768,23 @@ void common_hal_bno080_BNO080_construct(bno080_BNO080_obj_t *self, busio_spi_obj
     common_hal_digitalio_digitalinout_construct(&self->irq, irq);
     common_hal_digitalio_digitalinout_set_irq(&self->irq, EDGE_FALL, PULL_UP, bno080_isr_recv, self);
 
+    // Initialize data arrays to valid float objects (0.0)
+    for (int i = 0; i < QUAT_DIMENSION; i++) {
+        self->fquat[i] = mp_obj_new_float(0.0f);
+    }
+    for (int i = 0; i < ACCEL_DIMENSION; i++) {
+        self->accel[i] = mp_obj_new_float(0.0f);
+    }
+    for (int i = 0; i < GYRO_DIMENSION; i++) {
+        self->gyro[i] = mp_obj_new_float(0.0f);
+    }
+    for (int i = 0; i < MAG_DIMENSION; i++) {
+        self->mag[i] = mp_obj_new_float(0.0f);
+    }
+    for (int i = 0; i < GRAV_DIMENSION; i++) {
+        self->grav[i] = mp_obj_new_float(0.0f);
+    }
+
     lock_bus(self);
     common_hal_busio_spi_configure(self->bus, BNO_BAUDRATE, 1, 1, 8);
     unlock_bus(self);
@@ -803,6 +820,23 @@ void common_hal_bno080_BNO080_reset(bno080_BNO080_obj_t *self) {
     // clear seqnums
     memset(self->read_seqnums, 0xff, sizeof(self->read_seqnums));
     memset(self->write_seqnums, 0x00, sizeof(self->write_seqnums));
+
+    // Re-initialize data arrays to valid float objects (0.0)
+    for (int i = 0; i < QUAT_DIMENSION; i++) {
+        self->fquat[i] = mp_obj_new_float(0.0f);
+    }
+    for (int i = 0; i < ACCEL_DIMENSION; i++) {
+        self->accel[i] = mp_obj_new_float(0.0f);
+    }
+    for (int i = 0; i < GYRO_DIMENSION; i++) {
+        self->gyro[i] = mp_obj_new_float(0.0f);
+    }
+    for (int i = 0; i < MAG_DIMENSION; i++) {
+        self->mag[i] = mp_obj_new_float(0.0f);
+    }
+    for (int i = 0; i < GRAV_DIMENSION; i++) {
+        self->grav[i] = mp_obj_new_float(0.0f);
+    }
 }
 
 STATIC void bno080_unary_rotation(bno080_BNO080_obj_t *self, uint8_t feature) {
@@ -814,6 +848,7 @@ STATIC void bno080_unary_rotation(bno080_BNO080_obj_t *self, uint8_t feature) {
         case BNO080_SRID_ROTATION_VECTOR:
             if (self->selected_rotation != 0 && self->selected_rotation != feature) {
                 uint8_t disable = self->selected_rotation;
+                mp_printf(&mp_plat_print, "unary_rotation: Disabling feature %d\n", disable);
                 common_hal_bno080_BNO080_set_feature(self, disable, 0, 0, 0, 0, 0);
             }
             self->selected_rotation = feature;
@@ -825,8 +860,9 @@ STATIC void bno080_unary_rotation(bno080_BNO080_obj_t *self, uint8_t feature) {
 
 int common_hal_bno080_BNO080_set_feature(bno080_BNO080_obj_t *self, uint8_t feature, uint32_t refresh_us, uint32_t batch_us, uint8_t flags, uint16_t sns, uint32_t cfg) {
     int rc = 0;
+    mp_printf(&mp_plat_print, "checking rotation for feature %d\n", feature);
     bno080_unary_rotation(self, feature);
-
+    mp_printf(&mp_plat_print, "defining command for feature %d\n", feature);
 
     const uint8_t command[17] = {
         BNO080_SET_FEATURE_COMMAND,
@@ -868,14 +904,45 @@ mp_obj_t common_hal_bno080_BNO080_read(bno080_BNO080_obj_t *self, uint8_t report
         case BNO080_SRID_GEOMAGNETIC_ROTATION_VECTOR:
         case BNO080_SRID_GAME_ROTATION_VECTOR:
         case BNO080_SRID_ROTATION_VECTOR:
+            // Defensive: check for NULLs and re-initialize if needed
+            for (int i = 0; i < QUAT_DIMENSION; i++) {
+                if (self->fquat[i] == NULL) {
+                    mp_printf(&mp_plat_print, "Warning: fquat[%d] was NULL, reinitializing to 0.0\n", i);
+                    self->fquat[i] = mp_obj_new_float(0.0f);
+                }
+            }
             return mp_obj_new_list(QUAT_DIMENSION, self->fquat);
         case BNO080_SRID_ACCELEROMETER:
+            for (int i = 0; i < ACCEL_DIMENSION; i++) {
+                if (self->accel[i] == NULL) {
+                    mp_printf(&mp_plat_print, "Warning: accel[%d] was NULL, reinitializing to 0.0\n", i);
+                    self->accel[i] = mp_obj_new_float(0.0f);
+                }
+            }
             return mp_obj_new_list(ACCEL_DIMENSION, self->accel);
         case BNO080_SRID_GYROSCOPE:
+            for (int i = 0; i < GYRO_DIMENSION; i++) {
+                if (self->gyro[i] == NULL) {
+                    mp_printf(&mp_plat_print, "Warning: gyro[%d] was NULL, reinitializing to 0.0\n", i);
+                    self->gyro[i] = mp_obj_new_float(0.0f);
+                }
+            }
             return mp_obj_new_list(GYRO_DIMENSION, self->gyro);
         case BNO080_SRID_MAGNETIC_FIELD:
+            for (int i = 0; i < MAG_DIMENSION; i++) {
+                if (self->mag[i] == NULL) {
+                    mp_printf(&mp_plat_print, "Warning: mag[%d] was NULL, reinitializing to 0.0\n", i);
+                    self->mag[i] = mp_obj_new_float(0.0f);
+                }
+            }
             return mp_obj_new_list(MAG_DIMENSION, self->mag);
         case BNO080_SRID_GRAVITY:
+            for (int i = 0; i < GRAV_DIMENSION; i++) {
+                if (self->grav[i] == NULL) {
+                    mp_printf(&mp_plat_print, "Warning: grav[%d] was NULL, reinitializing to 0.0\n", i);
+                    self->grav[i] = mp_obj_new_float(0.0f);
+                }
+            }
             return mp_obj_new_list(GRAV_DIMENSION, self->grav);
     }
 

--- a/shared-module/bno080/BNO080.c
+++ b/shared-module/bno080/BNO080.c
@@ -848,7 +848,6 @@ STATIC void bno080_unary_rotation(bno080_BNO080_obj_t *self, uint8_t feature) {
         case BNO080_SRID_ROTATION_VECTOR:
             if (self->selected_rotation != 0 && self->selected_rotation != feature) {
                 uint8_t disable = self->selected_rotation;
-                mp_printf(&mp_plat_print, "unary_rotation: Disabling feature %d\n", disable);
                 common_hal_bno080_BNO080_set_feature(self, disable, 0, 0, 0, 0, 0);
             }
             self->selected_rotation = feature;
@@ -860,9 +859,7 @@ STATIC void bno080_unary_rotation(bno080_BNO080_obj_t *self, uint8_t feature) {
 
 int common_hal_bno080_BNO080_set_feature(bno080_BNO080_obj_t *self, uint8_t feature, uint32_t refresh_us, uint32_t batch_us, uint8_t flags, uint16_t sns, uint32_t cfg) {
     int rc = 0;
-    mp_printf(&mp_plat_print, "checking rotation for feature %d\n", feature);
     bno080_unary_rotation(self, feature);
-    mp_printf(&mp_plat_print, "defining command for feature %d\n", feature);
 
     const uint8_t command[17] = {
         BNO080_SET_FEATURE_COMMAND,

--- a/shared-module/bno080/BNO080.c
+++ b/shared-module/bno080/BNO080.c
@@ -824,9 +824,6 @@ void common_hal_bno080_BNO080_reset(bno080_BNO080_obj_t *self) {
     // clear seqnums
     memset(self->read_seqnums, 0xff, sizeof(self->read_seqnums));
     memset(self->write_seqnums, 0x00, sizeof(self->write_seqnums));
-
-    // Re-initialize data arrays to valid float objects (0.0)
-    bno080_init_data_arrays(self);
 }
 
 STATIC void bno080_unary_rotation(bno080_BNO080_obj_t *self, uint8_t feature) {

--- a/shared-module/bno080/BNO080.c
+++ b/shared-module/bno080/BNO080.c
@@ -753,6 +753,24 @@ STATIC void bno080_isr_recv(void *arg) {
     bno080_spi_sample(self);
 }
 
+STATIC void bno080_init_data_arrays(bno080_BNO080_obj_t *self) {
+    for (int i = 0; i < QUAT_DIMENSION; i++) {
+        self->fquat[i] = mp_obj_new_float(0.0f);
+    }
+    for (int i = 0; i < ACCEL_DIMENSION; i++) {
+        self->accel[i] = mp_obj_new_float(0.0f);
+    }
+    for (int i = 0; i < GYRO_DIMENSION; i++) {
+        self->gyro[i] = mp_obj_new_float(0.0f);
+    }
+    for (int i = 0; i < MAG_DIMENSION; i++) {
+        self->mag[i] = mp_obj_new_float(0.0f);
+    }
+    for (int i = 0; i < GRAV_DIMENSION; i++) {
+        self->grav[i] = mp_obj_new_float(0.0f);
+    }
+}
+
 void common_hal_bno080_BNO080_construct(bno080_BNO080_obj_t *self, busio_spi_obj_t *bus, const mcu_pin_obj_t *cs, const mcu_pin_obj_t *rst, const mcu_pin_obj_t *ps0, const mcu_pin_obj_t *bootn, const mcu_pin_obj_t *irq) {
     self->bus = bus;
     self->resp = 0;
@@ -769,21 +787,7 @@ void common_hal_bno080_BNO080_construct(bno080_BNO080_obj_t *self, busio_spi_obj
     common_hal_digitalio_digitalinout_set_irq(&self->irq, EDGE_FALL, PULL_UP, bno080_isr_recv, self);
 
     // Initialize data arrays to valid float objects (0.0)
-    for (int i = 0; i < QUAT_DIMENSION; i++) {
-        self->fquat[i] = mp_obj_new_float(0.0f);
-    }
-    for (int i = 0; i < ACCEL_DIMENSION; i++) {
-        self->accel[i] = mp_obj_new_float(0.0f);
-    }
-    for (int i = 0; i < GYRO_DIMENSION; i++) {
-        self->gyro[i] = mp_obj_new_float(0.0f);
-    }
-    for (int i = 0; i < MAG_DIMENSION; i++) {
-        self->mag[i] = mp_obj_new_float(0.0f);
-    }
-    for (int i = 0; i < GRAV_DIMENSION; i++) {
-        self->grav[i] = mp_obj_new_float(0.0f);
-    }
+    bno080_init_data_arrays(self);
 
     lock_bus(self);
     common_hal_busio_spi_configure(self->bus, BNO_BAUDRATE, 1, 1, 8);
@@ -822,21 +826,7 @@ void common_hal_bno080_BNO080_reset(bno080_BNO080_obj_t *self) {
     memset(self->write_seqnums, 0x00, sizeof(self->write_seqnums));
 
     // Re-initialize data arrays to valid float objects (0.0)
-    for (int i = 0; i < QUAT_DIMENSION; i++) {
-        self->fquat[i] = mp_obj_new_float(0.0f);
-    }
-    for (int i = 0; i < ACCEL_DIMENSION; i++) {
-        self->accel[i] = mp_obj_new_float(0.0f);
-    }
-    for (int i = 0; i < GYRO_DIMENSION; i++) {
-        self->gyro[i] = mp_obj_new_float(0.0f);
-    }
-    for (int i = 0; i < MAG_DIMENSION; i++) {
-        self->mag[i] = mp_obj_new_float(0.0f);
-    }
-    for (int i = 0; i < GRAV_DIMENSION; i++) {
-        self->grav[i] = mp_obj_new_float(0.0f);
-    }
+    bno080_init_data_arrays(self);
 }
 
 STATIC void bno080_unary_rotation(bno080_BNO080_obj_t *self, uint8_t feature) {


### PR DESCRIPTION
I'm trying to stabilize the native bno implementation for circuitpython as part of the work to clean up the cionic-circuitpython repo. I was running into nondeterministic hard faults due to invalid memory accesses for a while so tried to dig in and identify the root cause. I found out that the cause for this is in this function:
```
mp_obj_t common_hal_bno080_BNO080_read(bno080_BNO080_obj_t *self, uint8_t report_id) {
    // mp_obj_t fquat[QUAT_DIMENSION];
    // int rc = 0;

    switch (report_id) {
        case BNO080_SRID_ARVR_GAME_ROTATION_VECTOR:
        case BNO080_SRID_ARVR_ROTATION_VECTOR:
        case BNO080_SRID_GEOMAGNETIC_ROTATION_VECTOR:
        case BNO080_SRID_GAME_ROTATION_VECTOR:
        case BNO080_SRID_ROTATION_VECTOR:
            mp_printf(&mp_plat_print, "[module] read: returning rotation vector\n");
            // print fquat ptrs
            mp_printf(&mp_plat_print, "self=%p, self->fquat=%p\n", self, self->fquat);
            for (int i = 0; i < QUAT_DIMENSION; i++) {
                mp_printf(&mp_plat_print, "fquat[%d] ptr=%p\n", i, self->fquat[i]);
            }
            // print fquat values
            for (int i = 0; i < QUAT_DIMENSION; i++) {
                mp_printf(&mp_plat_print, "fquat[%d] value=%f\n", i, (double)mp_obj_get_float(self->fquat[i]));
            }
            return mp_obj_new_list(QUAT_DIMENSION, self->fquat);
        case BNO080_SRID_ACCELEROMETER:
            mp_printf(&mp_plat_print, "[module] read: returning accelerometer data\n");
            return mp_obj_new_list(ACCEL_DIMENSION, self->accel);
        case BNO080_SRID_GYROSCOPE:
            mp_printf(&mp_plat_print, "[module] read: returning gyroscope data\n");
            return mp_obj_new_list(GYRO_DIMENSION, self->gyro);
        case BNO080_SRID_MAGNETIC_FIELD:
            mp_printf(&mp_plat_print, "[module] read: returning magnetic field data\n");
            return mp_obj_new_list(MAG_DIMENSION, self->mag);
        case BNO080_SRID_GRAVITY:
            mp_printf(&mp_plat_print, "[module] read: returning gravity data\n");
            return mp_obj_new_list(GRAV_DIMENSION, self->grav);
    }

    return NULL;
} 
```
and it seems to be that the fquat ptrs are sometimes uninitialized when the python layer calls `bno080.read()` for the first time. This happens when `bno080_report_rotation` hasn't been called yet (i.e. if the ISR has not picked up the channel report yet). I'm pretty confident that this is the problem but I wasn't as sure about the best fix. In my head the options were:

- initialize the fquat ptrs in the constructor instead
- add a check for null/ invalid ptrs in the read function
- add a timeout to the set feature function (to wait for the report to get picked up after setting the feature) -- this could happen in the C or the Python layer

Here, I implemented bullet 1 and 2 to be extra defensive. I initialized data pointers in the constructor and _also_ check for invalid ptrs in the read function.

Note that this implementation will lead to some garbage values (0,0,0,0) for data streams in the case that a crash would have happened instead. A future implementation could be to return NULL instead of garbage values and update the python-side CionicOrientation class implementation to handle cases where bno08x.read() returns NULL, but I went with this because there are many examples in cionic-circuitpython in non-main branches which would also be affected by this change.